### PR TITLE
fix setup.py paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=['tgt'],
     scripts=[
     	'scripts/tgt-concatenate-textgrids.py',
-        'tgt-extract-part.py',
+        'scripts/tgt-extract-part.py',
     	'scripts/tgt-print-tiernames.py',
     ],
     maintainer='Hendrik Buschmeier',


### PR DESCRIPTION
`python setup.py install` fails because tgt-extract-part.py is in the `scripts` directory.