### PR TITLE
Add numpy to the setup.py 'install_required'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,4 +44,7 @@ setup(
     	'Programming Language :: Python :: 3.5',
     	'Topic :: Scientific/Engineering :: Information Analysis',
     ],
+    install_requires=[
+        'numpy',
+    ],
 )


### PR DESCRIPTION
The project relies on numpy, ins't it? `import tgt` fails without having numpy installed.